### PR TITLE
Wording suggestion

### DIFF
--- a/proposals/nnnn-implicit-raw-bitwise-conversion.md
+++ b/proposals/nnnn-implicit-raw-bitwise-conversion.md
@@ -143,7 +143,7 @@ Implicit casts from a FixedWidthInteger will continue to be supported without a 
     readBytes(&intArray)
     writeBytes(&intArray)
 
-Implicit casts from trivial collection elements, will continue to be supported without a warning:
+Implicit casts from bitwise copyable array elements, will continue to be supported without a warning:
 
     var byteArray: [UInt8] = [0]
     readBytes(&byteArray)


### PR DESCRIPTION
A leftover use of the word "trivial".

Relatedly, it seems like the example involving a string at line 152 should have some explanatory text.